### PR TITLE
Ignore src and .babelrc from published package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+.babelrc
+src

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "redux-persist-seamless-immutable",
+  "name": "@orangejellyfish/redux-persist-seamless-immutable",
   "version": "1.0.1",
   "description": "Use seamless-immutable with redux-persist v5",
   "main": "lib/index.js",


### PR DESCRIPTION
Quick hack to work around build issues in apps that try to use the .babelrc in this package inside node_modules