### PR TITLE
enhance transformer

### DIFF
--- a/src/transformer.js
+++ b/src/transformer.js
@@ -8,12 +8,31 @@ const fromImmutable = a => (isImmutable(a) ? convertToPojo(a) : a);
 // convert this JS object into an Immutable object
 const toImmutable = raw => Immutable(raw);
 
-const seamlessImmutableTransformer = createTransform(
-  // transform state coming from redux on its way to being serialized and stored
-  state => fromImmutable(state),
-  // transform state coming from storage, on its way to be rehydrated into redux
-  state => toImmutable(state)
-);
+const seamlessImmutableTransformer = ({ whitelistPerReducer = {}, blacklistPerReducer = {} }) => {
+  return createTransform(
+    // transform state coming from redux on its way to being serialized and stored
+    (state, key) => {
+      const reducedStateKeys = Object.keys(state);
+      if (whitelistPerReducer[key]) {
+        reducedStateKeys.forEach(item => {
+          if (!whitelistPerReducer[key].includes(item)) {
+            state = state.without(item);
+          }
+        });
+      }
+      if (blacklistPerReducer[key]) {
+        reducedStateKeys.forEach(item => {
+          if (blacklistPerReducer[key].includes(item)) {
+            state = state.without(item);
+          }
+        });
+      }
+      return fromImmutable(state);
+    },
+    // transform state coming from storage, on its way to be rehydrated into redux
+    state => toImmutable(state)
+  );
+};
 
 module.exports = {
   seamlessImmutableTransformer


### PR DESCRIPTION
transformer can now accept whitelist and blacklist for every reducer.

```
import { seamlessImmutableReconciler, seamlessImmutableTransformer } from 'redux-persist-seamless-immutable'

const fooConfig = {
  key: 'foo',
  storage: LocalStorage,
  stateReconciler: seamlessImmutableReconciler,
  transforms: [
    seamlessImmutableTransformer({
      whitelistPerReducer: {
          reducerA: ['keyA', 'keyB']
      },
      blacklistPerReducer: {
          reducerB: ['keyC', 'keyD']
      }
    })
  ]
};```