### PR TITLE
change the function name to align with latest code change

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,26 @@ You trod on. But, even after using a custom transformer, you then find v5 is con
 ### v5
 
 ```
-import { seamlessImmutableReconciler, seamlessImmutableTransformer } from 'redux-persist-seamless-immutable'
+import { seamlessImmutableReconciler, seamlessImmutableTransformCreator } from 'redux-persist-seamless-immutable'
 
 const fooConfig = {
   key: 'foo',
   storage: LocalStorage,
   stateReconciler: seamlessImmutableReconciler,
-  transforms: [seamlessImmutableTransformer]
+  transforms: [seamlessImmutableTransformCreator(transformerConfig)]
+}
+```
+
+#### tranformerConfig
+The transformer can accept a config object with the following keys: 
+```
+{
+  whitelistPerReducer: {
+      reducerA: ['keyA', 'keyB']
+  },
+  blacklistPerReducer: {
+      reducerB: ['keyC', 'keyD']
+  }
 }
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 const { seamlessImmutableReconciler } = require('./reconciler');
-const { seamlessImmutableTransformer } = require('./transformer');
+const { seamlessImmutableTransformCreator } = require('./transformer');
 
 module.exports = {
   seamlessImmutableReconciler,
-  seamlessImmutableTransformer
+  seamlessImmutableTransformCreator
 };

--- a/src/transformer.js
+++ b/src/transformer.js
@@ -8,7 +8,7 @@ const fromImmutable = a => (isImmutable(a) ? convertToPojo(a) : a);
 // convert this JS object into an Immutable object
 const toImmutable = raw => Immutable(raw);
 
-const seamlessImmutableTransformer = ({ whitelistPerReducer = {}, blacklistPerReducer = {} }) => {
+const seamlessImmutableTransformCreator = ({ whitelistPerReducer = {}, blacklistPerReducer = {} }) => {
   return createTransform(
     // transform state coming from redux on its way to being serialized and stored
     (state, key) => {
@@ -35,5 +35,5 @@ const seamlessImmutableTransformer = ({ whitelistPerReducer = {}, blacklistPerRe
 };
 
 module.exports = {
-  seamlessImmutableTransformer
+  seamlessImmutableTransformCreator
 };


### PR DESCRIPTION
First, Thanks for this great library!
Since the latest PR Change, `seamlessImmutableTransformer ` current has changed to a function which will generate the transform, so I think it will be better to change the name to align with this change