### PR TITLE
Update transformer.js to make sure the state is valid

### DIFF
--- a/src/transformer.js
+++ b/src/transformer.js
@@ -12,6 +12,9 @@ const seamlessImmutableTransformCreator = ({ whitelistPerReducer = {}, blacklist
   return createTransform(
     // transform state coming from redux on its way to being serialized and stored
     (state, key) => {
+      if (!state) {
+        return state
+      }
       const reducedStateKeys = Object.keys(state);
       if (whitelistPerReducer[key]) {
         reducedStateKeys.forEach(item => {


### PR DESCRIPTION
The redux lib allow to set initial state is null. But with your logic, don't check the state is null or not. So if the state is null, the `Object.keys` will throw exception. You can check the message of redux here: https://github.com/reduxjs/redux/blob/master/src/combineReducers.ts#L70

My PR to fix this issue. This issue happens on production of our app. Could you please help me review and make a new build for your lib.

Thanks so much